### PR TITLE
Fix survival inventory being copied into buildmode

### DIFF
--- a/src/main/kotlin/com/kruthers/gamemode4core/commands/UnwatchCommand.kt
+++ b/src/main/kotlin/com/kruthers/gamemode4core/commands/UnwatchCommand.kt
@@ -20,7 +20,7 @@ class UnwatchCommand(val plugin: Gamemode4Core): CommandExecutor {
 
                 if (playerData.getBoolean("mode.watching")) {
 
-                    Watching.disable(plugin, player, playerData)
+                    Watching.disable(plugin, player, playerData, true)
 
                 } else {
                     player.sendMessage("${ChatColor.RED}You must be watching someone to be able to unwatch")

--- a/src/main/kotlin/com/kruthers/gamemode4core/commands/WatchConfirmCommand.kt
+++ b/src/main/kotlin/com/kruthers/gamemode4core/commands/WatchConfirmCommand.kt
@@ -29,7 +29,7 @@ class WatchConfirmCommand(val plugin: Gamemode4Core): CommandExecutor {
 
                     if (target == null) {
                         player.sendMessage("${ChatColor.RED}Unable to locate target, exiting watch mode")
-                        Watching.disable(plugin, player, playerData)
+                        Watching.disable(plugin, player, playerData, true)
                     } else {
                         if (target.isOnline) {
                             target.player?.let { player.teleport(it.location) }

--- a/src/main/kotlin/com/kruthers/gamemode4core/events/PlayerConnectionEvents.kt
+++ b/src/main/kotlin/com/kruthers/gamemode4core/events/PlayerConnectionEvents.kt
@@ -140,7 +140,7 @@ class PlayerConnectionEvents(val plugin: Gamemode4Core): Listener {
                     val target: OfflinePlayer? = playerData.getString("storage.watching.target")?.let { Bukkit.getOfflinePlayer(UUID.fromString(it)) }
 
                     if (target == null) {
-                        Watching.disable(plugin, player, playerData)
+                        Watching.disable(plugin, player, playerData, true)
                     } else {
                         player.sendMessage(getMessage(plugin, "watch.join").replace("{target}",target.name?:"null"))
                         Gamemode4Core.watchingPlayers[player] = target.uniqueId

--- a/src/main/kotlin/com/kruthers/gamemode4core/modes/ModMode.kt
+++ b/src/main/kotlin/com/kruthers/gamemode4core/modes/ModMode.kt
@@ -75,7 +75,7 @@ class ModMode {
             var playerData: YamlConfiguration = pd
             //disabling watching
             if (playerData.getBoolean("mode.watching")){
-                playerData = Watching.disable(plugin, player, playerData)
+                playerData = Watching.disable(plugin, player, playerData, false)
             }
 
             // save mode inventory

--- a/src/main/kotlin/com/kruthers/gamemode4core/modes/Watching.kt
+++ b/src/main/kotlin/com/kruthers/gamemode4core/modes/Watching.kt
@@ -49,7 +49,7 @@ class Watching {
 
         }
 
-        fun disable(plugin: Gamemode4Core, player: Player, pd: YamlConfiguration): YamlConfiguration {
+        fun disable(plugin: Gamemode4Core, player: Player, pd: YamlConfiguration, disableModMode: Boolean): YamlConfiguration {
             var playerData: YamlConfiguration = pd;
             //set watching to false
             playerData.set("mode.watching",false);
@@ -70,7 +70,7 @@ class Watching {
             Gamemode4Core.watchingPlayers.remove(player)
 
             //check if they only entered mod mode to use watch mode
-            if (playerData.getBoolean("storage.watching.watchEntrance")) {
+            if (disableModMode && playerData.getBoolean("storage.watching.watchEntrance")) {
                 playerData = ModMode.disable(plugin,player,playerData)
             }
 


### PR DESCRIPTION
When watching someone when not in modmode and then exiting modmode then modmode will disable twice. 
This causes the survival data to be saved to the build mode data.
This adds a parameters to prevent watchmode from disabling modmode in the case where modmode is already disabling itself.